### PR TITLE
fix(statistics): Use robust date parsing for monthly chart

### DIFF
--- a/src/components/FinancialCharts.tsx
+++ b/src/components/FinancialCharts.tsx
@@ -4,7 +4,7 @@ import {
   PieChart, Pie, Cell, Legend
 } from 'recharts';
 import { formatCurrency } from '../utils/dateUtils';
-import { format, parseISO, startOfMonth, endOfMonth, eachDayOfInterval, getMonth, getYear } from 'date-fns';
+import { format, parse, parseISO, startOfMonth, endOfMonth, eachDayOfInterval, getMonth, getYear } from 'date-fns';
 import { id } from 'date-fns/locale';
 import { useTheme } from '../context/ThemeContext';
 import { useTransactions } from '../hooks/useTransactions';
@@ -41,7 +41,11 @@ const FinancialCharts: React.FC<FinancialChartsProps> = ({ onRefresh }) => {
 
     const sortedData = Array.from(monthlyDataMap.entries())
       .map(([name, values]) => ({ name, ...values }))
-      .sort((a, b) => parseISO(format(new Date(`1 ${a.name}`), 'yyyy-MM-dd')).getTime() - parseISO(format(new Date(`1 ${b.name}`), 'yyyy-MM-dd')).getTime());
+      .sort((a, b) => {
+        const dateA = parse(a.name, 'MMM yyyy', new Date(), { locale: id });
+        const dateB = parse(b.name, 'MMM yyyy', new Date(), { locale: id });
+        return dateA.getTime() - dateB.getTime();
+      });
 
     return sortedData;
   };


### PR DESCRIPTION
The monthly trend chart in the statistics menu was failing due to unreliable date parsing. The code used `new Date('1 Agu 2025')` to parse month strings, which is not consistent across JavaScript environments and can lead to invalid dates.

This commit fixes the issue by using the `parse` function from the `date-fns` library, which is already a dependency. The new implementation correctly parses the 'MMM yyyy' date format with the Indonesian locale, ensuring that the monthly trend data is always sorted chronologically and the chart renders correctly.